### PR TITLE
continue on list errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,14 @@ var (
 	tmpl = template.Must(template.New("haproxy").Parse(haproxyconf))
 )
 
+type ListError struct {
+	e error
+}
+
+func (l ListError) Error() string {
+	return l.e.Error()
+}
+
 type Config struct {
 	path, baseDomain string
 	client           unversioned.IngressInterface
@@ -50,7 +58,7 @@ type acl struct {
 func (c Config) Update() error {
 	l, err := c.client.List(api.ListOptions{})
 	if err != nil {
-		return err
+		return ListError{err}
 	}
 
 	if reflect.DeepEqual(l.Items, c.previous.Items) {

--- a/main.go
+++ b/main.go
@@ -43,7 +43,13 @@ func main() {
 		ratelimiter.Accept()
 		err := c.Update()
 		if err != nil {
-			log.Fatalf("failed to update file: %v", err)
+			switch err.(type) {
+			case config.ListError:
+				log.Printf("failed to list ingresses: %s", err.Error())
+				continue
+			default:
+				log.Fatalf("failed to update file: %v", err)
+			}
 		}
 
 		shellout(fmt.Sprintf("haproxy -f %s -p /var/run/haproxy.pid -sf $(cat /var/run/haproxy.pid)", path))


### PR DESCRIPTION
In the event we can't talk to the k8s API we'll log it and continue. Prevents LB's from disappearing when we hit an error talking to the API (during upgrades).

cc @tam7t @fatih
