### PR TITLE
prevent the zombie apocalypse

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -45,7 +45,7 @@ frontend ingress
 	capture request header Host len 64
 
 	# JSON logging for ES: http://www.rsyslog.com/json-elasticsearch/
-	log-format @cee:{"program":"haproxy","timestamp":%Ts,"http_status":%ST,"http_request":"%r","remote_addr":"%ci","bytes_read":%B,"upstream_addr":"%si","backend_name":"%b","retries":%rc,"bytes_uploaded":%U,"upstream_response_time":"%Tr","upstream_connect_time":"%Tc","session_duration":"%Tt","termination_state":"%ts","user_agent":"%[capture.req.hdr(1),json]","request_host":"%[capture.req.hdr(2),json]","host":"{{.Hostname}}"}
+	log-format @cee:{"program":"haproxy","timestamp":%Ts,"http_status":%ST,"http_request":"%r","remote_addr":"%ci","bytes_read":%B,"upstream_addr":"%si","backend_name":"%b","retries":%rc,"bytes_uploaded":%U,"upstream_response_time":"%Tr","upstream_connect_time":"%Tc","session_duration":"%Tt","termination_state":"%ts","user_agent":"%[capture.req.hdr(1),json("utf8s")]","request_host":"%[capture.req.hdr(2),json("utf8s")]","host":"{{.Hostname}}"}
 
 	# Host ACLs
 {{ range $acl := .HostACLs }}

--- a/main.go
+++ b/main.go
@@ -74,7 +74,10 @@ func main() {
 		}
 
 		if changed {
+			log.Print("reloading haproxy")
 			go reloadHaproxy(path)
+		} else {
+			log.Print("haproxy config unchanged")
 		}
 	}
 }


### PR DESCRIPTION
When reloading HAProxy we'll register a goroutine to `Wait4` the previous `haproxy` PID. This will prevent zombie processes from piling up. Each goroutine will handle cleaning up a single PID.

This PR also makes the haproxy start/reload process synchronous. This is to prevent a race condition when we tell haproxy to start then immediately try to restart it before the original call has written its pid out to a file. This lead to multiple `haproxy` daemons running at once.

I also fixed a bug I noticed with the `log-format` rules due to lacking haproxy docs.

The logs for `hing` will now look like:

```
2016/03/14 20:43:40 reloading haproxy
2016/03/14 20:43:40 reaping process 79
2016/03/14 20:43:40 reaped process 79
2016/03/14 20:43:50 reloading haproxy
2016/03/14 20:43:50 reaping process 81
2016/03/14 20:43:50 reaped process 81
```
#6 addresses better reloads (to prevent constant reloading).
